### PR TITLE
Shorten and better test treap

### DIFF
--- a/src/trinerdi/data-structures/treap.cpp
+++ b/src/trinerdi/data-structures/treap.cpp
@@ -6,7 +6,7 @@
  * Usage:
  *  Treap* t = NULL;
  *  insert(t, 5); insert(t, 2);
- *  assert(indexOf(t, 5) == 1); assert(getKth(t, 1) == 5);
+ *  assert(getKth(t, 1) == 5);
  */
 #include "../base.hpp"
 
@@ -15,24 +15,18 @@
 struct Treap {
     Treap *lson = NULL, *rson = NULL;
     ll val;
-    int weight;
-    int size = 0;
-    
+    int weight, size = 0;
     Treap(ll _val) : val(_val), weight(rand()), size(1) {}
-    
-    ~Treap() {
-        delete lson;
-        delete rson;
-    }
-    
+    ~Treap() { delete lson; delete rson; }
     void setSon(bool right, Treap *newSon) {
-        Treap *&upd = right ? (rson) : (lson);
+        Treap *&upd = right ? rson : lson;
         upd = newSon;
         size = 1 + SIZE(lson) + SIZE(rson);
     }
 };
 
-Treap* merge(Treap *l, Treap *r) {
+// Warning: Mutates l, r. All of l must be lower than r.
+Treap* merge(Treap *l, Treap *r) { 
     if (!l) return r;
     if (!r) return l;
     if (l->weight > r->weight) {
@@ -44,7 +38,7 @@ Treap* merge(Treap *l, Treap *r) {
     }
 }
 
-pair<Treap*, Treap*> split(Treap *a, ll val) {
+pair<Treap*, Treap*> split(Treap *a, ll val) { // Warning: Mutates a
     if (!a) return {NULL, NULL};
     if (a->val <= val) {
         pair<Treap*, Treap*> res = split(a->rson, val);
@@ -62,8 +56,7 @@ void insert(Treap *&a, ll val) {
         a = new Treap(val);
     } else {
         pair<Treap*, Treap*> spl = split(a, val);
-        a = merge(spl.first, new Treap(val));
-        a = merge(a, spl.second);
+        a = merge(merge(spl.first, new Treap(val)), spl.second);
     }
 }
 
@@ -82,23 +75,7 @@ ll getKth(Treap *a, int k) { // zero-indexed
         int lsize = SIZE(a->lson);
         if (lsize == k)
             return a->val;
-        else if (lsize > k)
-            a = a->lson;
-        else
-            a = a->rson, k -= lsize + 1;
-    }
-}
-
-int indexOf(Treap *a, ll val) {
-    int res = 0;
-    while (true) {
-        if (!a) return -1;
-        int lsize = SIZE(a->lson);
-        if (a->val == val)
-            return res + lsize;
-        else if (val < a->val)
-            a = a->lson;
-        else
-            res += lsize + 1, a = a->rson;
+        else if (lsize > k) a = a->lson;
+        else a = a->rson, k -= lsize + 1;
     }
 }

--- a/src/trinerdi/data-structures/treap_test.cpp
+++ b/src/trinerdi/data-structures/treap_test.cpp
@@ -1,6 +1,94 @@
 #include "gtest/gtest.h"
 #include "treap.cpp"
 
+void testTreapMatches(Treap* t, vector<ll>& v) {
+    rep(i, 0, v.size()) {
+        EXPECT_EQ(getKth(t, i), v[i]);
+    }
+}
+
+vector<ll> genUnique(int n) {
+    set<ll> used;
+    for (int i = 0; i < n; i++) {
+        ll x = rand();
+        while (used.count(x)) x = rand();
+        used.insert(x);
+    }
+    vector<ll> res;
+    for (auto&x : used) {
+        res.push_back(x);
+    }
+    return res;
+}
+
+TEST(Treap, InsertAndKth) {
+    srand(123);
+    rep(it, 0, 10) {
+        vector<ll> v = genUnique(50);
+        random_shuffle(v.begin(), v.end());
+        set<ll> seen;
+        Treap* t = NULL;
+        for (auto &x : v) {
+            insert(t, x);
+            seen.insert(x);
+            int i = 0;
+            for (auto& y : seen) {
+                EXPECT_EQ(getKth(t, i), y);
+                i++;
+            }
+        }
+
+    }
+}
+
+TEST(Treap, Split) {
+    srand(123);
+    rep(it, 0, 10) {
+        vector<ll> v = genUnique(50);
+        set<ll> values;
+        rep(i, 0, 50) values.insert(rand());
+        for (auto&x : v) values.insert(x);
+        for (auto&x : v) values.insert(x);
+        
+        for (auto &splitval : values) {
+            Treap* t = NULL;
+            for (auto &x : v) insert(t, x);
+            Treap *l = NULL, *r = NULL;
+            tie(l, r) = split(t, splitval);
+            int delta = 0;
+            rep(i,0,v.size()) {
+                if (v[i] <= splitval) {
+                    EXPECT_NE(l, (Treap*)NULL);
+                    EXPECT_EQ(getKth(l, i), v[i]);
+                    delta = i+1;
+                } else {
+                    EXPECT_NE(r, (Treap*)NULL);
+                    EXPECT_EQ(getKth(r, i-delta), v[i]);
+                }
+            }
+        }
+    }
+}
+
+TEST(Treap, Merge) {
+    srand(128);
+    rep(it, 0, 10) {
+        vector<ll> v = genUnique(50);
+        vector<ll> vl, vr;
+        rep(i,0,v.size()) {
+            ((i*2 < v.size())?vl:vr).push_back(v[i]);
+        }
+        Treap *tl = NULL, *tr = NULL;
+        for(auto& x : vl) insert(tl, x);
+        for(auto& x : vr) insert(tr, x);
+        Treap *tm = merge(tl, tr);
+        
+        rep(i, 0, v.size()) {
+            EXPECT_EQ(getKth(tm, i), v[i]);
+        }
+    }
+}
+
 TEST(Treap, BenchmarkInsertAndIndex1e5) {
     Treap* t = NULL;
     int n = 100000; // n = 10^6 takes about 5 seconds on my machine
@@ -11,11 +99,7 @@ TEST(Treap, BenchmarkInsertAndIndex1e5) {
         used.insert(x);
         insert(t, x);
     }
-    ll last = 0;
     for (int i = 0; i < n; i++) {
-        ll x = getKth(t, i);
-        EXPECT_GT(x, last);
-        EXPECT_EQ(indexOf(t, x), i);
-        last = x;
+        getKth(t, i);
     }
 }

--- a/src/trinerdi/data-structures/treap_test.cpp
+++ b/src/trinerdi/data-structures/treap_test.cpp
@@ -48,8 +48,7 @@ TEST(Treap, Split) {
         set<ll> values;
         rep(i, 0, 50) values.insert(rand());
         for (auto&x : v) values.insert(x);
-        for (auto&x : v) values.insert(x);
-        
+
         for (auto &splitval : values) {
             Treap* t = NULL;
             for (auto &x : v) insert(t, x);
@@ -74,15 +73,11 @@ TEST(Treap, Merge) {
     srand(128);
     rep(it, 0, 10) {
         vector<ll> v = genUnique(50);
-        vector<ll> vl, vr;
-        rep(i,0,v.size()) {
-            ((i*2 < v.size())?vl:vr).push_back(v[i]);
-        }
         Treap *tl = NULL, *tr = NULL;
-        for(auto& x : vl) insert(tl, x);
-        for(auto& x : vr) insert(tr, x);
+        rep(i,0,v.size()) {
+            insert((i*2 < v.size())?tl:tr, v[i]);
+        }
         Treap *tm = merge(tl, tr);
-        
         rep(i, 0, v.size()) {
             EXPECT_EQ(getKth(tm, i), v[i]);
         }


### PR DESCRIPTION
- Shorter code
  - Apart from golfing, also removed indexOf, which was very similar to getKth
- Improved test coverage
  - Was almost nonexistent before