### PR TITLE
Export: Fix bad whitespace/comment striping in the line hashing function

### DIFF
--- a/export/build
+++ b/export/build
@@ -16,7 +16,8 @@ def checksum(line):
     if len(line) == 0:  # Print nothing for an empty line
         return ""
 
-    line = re.sub(r"\s*|//.*", r"", line)
+    line = re.sub(r"//.*", r"", line)
+    line = re.sub(r"\s*", r"", line)
     if len(line) == 0:  # Indent a comment-only line properly
         return " " * numchars
 


### PR DESCRIPTION
The regexp in the `checksum` function that should take care of stripping comments and whitespace actually didn't work as expected. This resulted in `//` comments contributing to the created hashes.